### PR TITLE
Fix shifted events by one day

### DIFF
--- a/app/calendar/calendar-heatmap.tsx
+++ b/app/calendar/calendar-heatmap.tsx
@@ -19,7 +19,9 @@ export default function HeatMap({ startDate, endDate, events }) {
             ? {
                 "data-tooltip-id": "my-tooltip",
                 "data-tooltip-place": "top",
-		"data-tooltip-content": `${format(value.date)} has count: ${value.count}. Events: ${eventsByDate.get(format(value.date))}`,
+                "data-tooltip-content": `${format(value.date)} has count: ${
+                  value.count
+                }. Events: ${eventsByDate.get(format(value.date))}`,
               }
             : {
                 "data-tooltip-id": "my-tooltip",
@@ -28,7 +30,7 @@ export default function HeatMap({ startDate, endDate, events }) {
               };
         }}
         showWeekdayLabels={true}
-	weekdayLabels={['', 'Tue', '', 'Thu', '', 'Sat', '']}
+        weekdayLabels={["", "Tue", "", "Thu", "", "Sat", ""]}
         classForValue={(value) => {
           if (!value || value.count === 0) {
             return "color-empty";
@@ -78,9 +80,11 @@ export default function HeatMap({ startDate, endDate, events }) {
   }
 
   function format(date: Date): string {
-    let year = new Intl.DateTimeFormat('en', { year: 'numeric' }).format(date);
-    let month = new Intl.DateTimeFormat('en', { month: '2-digit' }).format(date);
-    let day = new Intl.DateTimeFormat('en', { day: '2-digit' }).format(date);
-    return day + '-' + month + '-' + year;
+    let year = new Intl.DateTimeFormat("en", { year: "numeric" }).format(date);
+    let month = new Intl.DateTimeFormat("en", { month: "2-digit" }).format(
+      date,
+    );
+    let day = new Intl.DateTimeFormat("en", { day: "2-digit" }).format(date);
+    return day + "-" + month + "-" + year;
   }
 }

--- a/app/calendar/calendar-heatmap.tsx
+++ b/app/calendar/calendar-heatmap.tsx
@@ -19,13 +19,7 @@ export default function HeatMap({ startDate, endDate, events }) {
             ? {
                 "data-tooltip-id": "my-tooltip",
                 "data-tooltip-place": "top",
-                "data-tooltip-content": `${value.date
-                  .toISOString()
-                  .slice(0, 10)} has count: ${
-                  value.count
-                }. Events: ${eventsByDate.get(
-                  value.date.toISOString().slice(0, 10),
-                )}`,
+		"data-tooltip-content": `${format(value.date)} has count: ${value.count}. Events: ${eventsByDate.get(format(value.date))}`,
               }
             : {
                 "data-tooltip-id": "my-tooltip",
@@ -34,6 +28,7 @@ export default function HeatMap({ startDate, endDate, events }) {
               };
         }}
         showWeekdayLabels={true}
+	weekdayLabels={['', 'Tue', '', 'Thu', '', 'Sat', '']}
         classForValue={(value) => {
           if (!value || value.count === 0) {
             return "color-empty";
@@ -58,9 +53,9 @@ export default function HeatMap({ startDate, endDate, events }) {
       let count = 0;
       for (var event of events) {
         if (
-          event.date_time.getUTCFullYear() === d.getUTCFullYear() &&
-          event.date_time.getUTCMonth() === d.getUTCMonth() &&
-          event.date_time.getUTCDate() === d.getUTCDate()
+          event.date_time.getFullYear() === d.getFullYear() &&
+          event.date_time.getMonth() === d.getMonth() &&
+          event.date_time.getDate() === d.getDate()
         ) {
           count = count + 1;
         }
@@ -73,12 +68,19 @@ export default function HeatMap({ startDate, endDate, events }) {
   function getEventsByDate(events: Event[]) {
     let newEvents = new Map<string, string[]>();
     for (var event of events) {
-      let key = event.date_time.toISOString().slice(0, 10);
+      let key = format(event.date_time);
       if (!newEvents.has(key)) {
         newEvents.set(key, []);
       }
       newEvents.get(key).push(event.name);
     }
     return newEvents;
+  }
+
+  function format(date: Date): string {
+    let year = new Intl.DateTimeFormat('en', { year: 'numeric' }).format(date);
+    let month = new Intl.DateTimeFormat('en', { month: '2-digit' }).format(date);
+    let day = new Intl.DateTimeFormat('en', { day: '2-digit' }).format(date);
+    return day + '-' + month + '-' + year;
   }
 }

--- a/app/calendar/calendar-page.tsx
+++ b/app/calendar/calendar-page.tsx
@@ -5,12 +5,13 @@ import EventCreator from "./event-creator";
 const fetcher = (url) => fetch(url).then((res) => res.json());
 
 export default function CalendarPage({ username }) {
-  const now = new Date();
+  const today = new Date();
+  today.setHours(0,0,0,0);
 
-  let startDate = new Date(now);
+  let startDate = new Date(today);
   startDate.setMonth(startDate.getMonth() - 6);
 
-  let endDate = new Date(now);
+  let endDate = new Date(today);
   endDate.setMonth(endDate.getMonth() + 6);
 
   const { data, error, isLoading, mutate } = useSWR(

--- a/app/calendar/calendar-page.tsx
+++ b/app/calendar/calendar-page.tsx
@@ -6,7 +6,7 @@ const fetcher = (url) => fetch(url).then((res) => res.json());
 
 export default function CalendarPage({ username }) {
   const today = new Date();
-  today.setHours(0,0,0,0);
+  today.setHours(0, 0, 0, 0);
 
   let startDate = new Date(today);
   startDate.setMonth(startDate.getMonth() - 6);

--- a/app/calendar/event-creator.tsx
+++ b/app/calendar/event-creator.tsx
@@ -80,11 +80,11 @@ export default function EventCreator({ username, onEventCreated }) {
         {" "}
         <label>Date: </label>{" "}
         <DatePicker
-	  showTimeInput
+          showTimeInput
           id="date"
           selected={date}
           onChange={(date) => setDate(date)}
-	  shouldCloseOnSelect={false}
+          shouldCloseOnSelect={false}
         />{" "}
       </div>{" "}
       <br />{" "}

--- a/app/calendar/event-creator.tsx
+++ b/app/calendar/event-creator.tsx
@@ -4,8 +4,10 @@ import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 
 export default function EventCreator({ username, onEventCreated }) {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
   const [name, setName] = useState("");
-  const [date, setDate] = useState("");
+  const [date, setDate] = useState(today);
   const [calendarId, setCalendarId] = useState("");
 
   function validateInput() {
@@ -78,6 +80,7 @@ export default function EventCreator({ username, onEventCreated }) {
         {" "}
         <label>Date: </label>{" "}
         <DatePicker
+	  showTimeInput
           id="date"
           selected={date}
           onChange={(date) => setDate(date)}

--- a/app/calendar/event-creator.tsx
+++ b/app/calendar/event-creator.tsx
@@ -24,7 +24,7 @@ export default function EventCreator({ username, onEventCreated }) {
       };
     }
 
-    if (date === null || date.length === 0) {
+    if (date === null) {
       const el = document.getElementById("date");
       el.style.border = errstyle;
       valid = false;
@@ -84,6 +84,7 @@ export default function EventCreator({ username, onEventCreated }) {
           id="date"
           selected={date}
           onChange={(date) => setDate(date)}
+	  shouldCloseOnSelect={false}
         />{" "}
       </div>{" "}
       <br />{" "}


### PR DESCRIPTION
This pr fixes the problem when the date is shifted by one day.
The main issue was due to the comparison:
```
event.date_time.getUTCFullYear() === d.getUTCFullYear() &&
event.date_time.getUTCMonth() === d.getUTCMonth() &&
event.date_time.getUTCDate() === d.getUTCDate()
```
Take for example the following case:
```
event.date_time = 09-09-2023 00:00:00 UTC+3 = 08-09-2023 21:00:00 UTC
d = 09-09-2023 15:00:00 UTC+3 = 09-09-2023 12:00:00 UTC
```

Notice that even though both dates are in the same day in UTC+3, they are different days in UTC.
The solution was to avoid comparing days in UTC, instead we are comparing the days in local time zone.

Another issue that caused inconsistencies was `toISOString()` - notice that this converts to a string in UTC timezone, we want to convert in local timezone instead, this is why `format` function was added.