### PR TITLE
Use types for better error checking

### DIFF
--- a/app/calendar/calendar-heatmap.tsx
+++ b/app/calendar/calendar-heatmap.tsx
@@ -3,7 +3,20 @@ import CalendarHeatmap from "react-calendar-heatmap";
 import { Tooltip } from "react-tooltip";
 import "react-calendar-heatmap/dist/styles.css";
 
-export default function HeatMap({ startDate, endDate, events }) {
+interface Value {
+  date: Date;
+  count: number;
+}
+
+export default function HeatMap({
+  startDate,
+  endDate,
+  events,
+}: {
+  startDate: Date;
+  endDate: Date;
+  events: Event[];
+}) {
   const values = getValues(events);
   const eventsByDate = getEventsByDate(events);
 
@@ -14,7 +27,7 @@ export default function HeatMap({ startDate, endDate, events }) {
         startDate={startDate}
         endDate={endDate}
         values={values}
-        tooltipDataAttrs={(value) => {
+        tooltipDataAttrs={(value: Value) => {
           return value.date != null
             ? {
                 "data-tooltip-id": "my-tooltip",
@@ -42,29 +55,29 @@ export default function HeatMap({ startDate, endDate, events }) {
     </>
   );
 
-  function getValues(events: Event[]) {
-    for (var event of events) {
+  function getValues(events: Event[]): Value[] {
+    for (let event of events) {
       event.date_time = new Date(event.date_time);
     }
 
     let newValues = [];
     let map = new Map<string, number>();
     for (
-      var date = new Date(startDate);
+      let date = new Date(startDate);
       date <= endDate;
       date.setDate(date.getDate() + 1)
     ) {
       map[format(date)] = 0;
     }
-    for (var event of events) {
-      var date = new Date(event.date_time);
+    for (let event of events) {
+      let date = new Date(event.date_time);
       date.setHours(0, 0, 0, 0);
 
       map[format(date)] = map[format(date)] + 1;
     }
 
     for (
-      var date = new Date(startDate);
+      let date = new Date(startDate);
       date <= endDate;
       date.setDate(date.getDate() + 1)
     ) {
@@ -73,9 +86,9 @@ export default function HeatMap({ startDate, endDate, events }) {
     return newValues;
   }
 
-  function getEventsByDate(events: Event[]) {
+  function getEventsByDate(events: Event[]): Map<string, string[]> {
     let newEvents = new Map<string, string[]>();
-    for (var event of events) {
+    for (let event of events) {
       let key = format(event.date_time);
       if (!newEvents.has(key)) {
         newEvents.set(key, []);

--- a/app/calendar/calendar-page.tsx
+++ b/app/calendar/calendar-page.tsx
@@ -4,7 +4,13 @@ import EventCreator from "./event-creator";
 
 const fetcher = (url) => fetch(url).then((res) => res.json());
 
-export default function CalendarPage({ username, password }) {
+export default function CalendarPage({
+  username,
+  password,
+}: {
+  username: string;
+  password: string;
+}) {
   const today = new Date();
   today.setHours(0, 0, 0, 0);
 

--- a/app/calendar/event-creator.tsx
+++ b/app/calendar/event-creator.tsx
@@ -4,23 +4,35 @@ import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 import { Base64 } from "js-base64";
 
-export default function EventCreator({ username, password, onEventCreated }) {
+interface EmptyFunction {
+  (): void;
+}
+
+export default function EventCreator({
+  username,
+  password,
+  onEventCreated,
+}: {
+  username: string;
+  password: string;
+  onEventCreated: EmptyFunction;
+}) {
   const today = new Date();
   today.setHours(0, 0, 0, 0);
   const [name, setName] = useState("");
   const [date, setDate] = useState(today);
 
   function validateInput() {
-    var valid = true;
-    var errstyle = "2px solid red";
-    var initstyle = "1px solid grey";
+    let valid = true;
+    let errstyle = "2px solid red";
+    let initstyle = "1px solid grey";
 
     if (name.length === 0) {
       const el = document.getElementById("name");
       el.style.border = errstyle;
       valid = false;
       el.onchange = () => {
-        (el.style.border = initstyle), (name) => setName(name);
+        (el.style.border = initstyle), (name: string) => setName(name);
       };
     }
 
@@ -29,7 +41,7 @@ export default function EventCreator({ username, password, onEventCreated }) {
       el.style.border = errstyle;
       valid = false;
       el.onclick = () => {
-        (el.style.border = initstyle), (date) => setDate(date);
+        (el.style.border = initstyle), (date: Date) => setDate(date);
       };
     }
     valid ? handleClick() : alert("Invalid Input");
@@ -75,7 +87,7 @@ export default function EventCreator({ username, password, onEventCreated }) {
           showTimeInput
           id="date"
           selected={date}
-          onChange={(date) => setDate(date)}
+          onChange={(date: Date) => setDate(date)}
           shouldCloseOnSelect={false}
         />{" "}
       </div>{" "}

--- a/app/user/user-creator.tsx
+++ b/app/user/user-creator.tsx
@@ -1,6 +1,10 @@
 import { useState } from "react";
 
-export default function Signup({ onSignup }) {
+export default function Signup({
+  onSignup,
+}: {
+  onSignup: (username: string, password: string) => void;
+}) {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
 
@@ -77,16 +81,17 @@ export default function Signup({ onSignup }) {
   );
 
   function validateInput() {
-    var valid = true;
-    var errstyle = "2px solid red";
-    var initstyle = "1px solid grey";
+    let valid = true;
+    let errstyle = "2px solid red";
+    let initstyle = "1px solid grey";
 
     if (username.length === 0) {
       const el = document.getElementById("username");
       el.style.border = errstyle;
       valid = false;
       el.onchange = () => {
-        (el.style.border = initstyle), (username) => setUsername(username);
+        (el.style.border = initstyle),
+          (username: string) => setUsername(username);
       };
     }
 
@@ -95,7 +100,8 @@ export default function Signup({ onSignup }) {
       el.style.border = errstyle;
       valid = false;
       el.onchange = () => {
-        (el.style.border = initstyle), (password) => setPassword(password);
+        (el.style.border = initstyle),
+          (password: string) => setPassword(password);
       };
     }
     valid ? handleClick() : alert("Invalid Input");
@@ -112,7 +118,7 @@ export default function Signup({ onSignup }) {
       valid = false;
       el.onchange = () => {
         (el.style.border = initstyle),
-          (usernameLogin) => setUsernameLogin(usernameLogin);
+          (usernameLogin: string) => setUsernameLogin(usernameLogin);
       };
     }
 
@@ -122,7 +128,7 @@ export default function Signup({ onSignup }) {
       valid = false;
       el.onchange = () => {
         (el.style.border = initstyle),
-          (passwordLogin) => setPasswordLogin(passwordLogin);
+          (passwordLogin: string) => setPasswordLogin(passwordLogin);
       };
     }
     valid ? handleClickLogin() : alert("Invalid Input");

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@types/node": "20.6.1",
         "@types/react": "18.2.21",
         "@types/react-calendar-heatmap": "^1.6.3",
+        "@types/react-datepicker": "^4.15.0",
         "prettier": "3.0.3",
         "typescript": "5.2.2"
       }
@@ -242,6 +243,18 @@
       "dev": true,
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-datepicker": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@types/react-datepicker/-/react-datepicker-4.15.0.tgz",
+      "integrity": "sha512-kr10s8ex4+MmCJmzdhA9kfmoMQBmsW5uDYDlH+8f/PgStrp7rRaz23Y/cvTiMgvESVq8ujDh4SOo6jlSwEw13g==",
+      "dev": true,
+      "dependencies": {
+        "@popperjs/core": "^2.9.2",
+        "@types/react": "*",
+        "date-fns": "^2.0.1",
+        "react-popper": "^2.2.5"
       }
     },
     "node_modules/@types/scheduler": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@types/node": "20.6.1",
     "@types/react": "18.2.21",
     "@types/react-calendar-heatmap": "^1.6.3",
+    "@types/react-datepicker": "^4.15.0",
     "prettier": "3.0.3",
     "typescript": "5.2.2"
   },


### PR DESCRIPTION
This change is necessary in order to take advantage of better Typescript support. 

Using types explicitly should help in catching errors early during compilation.

Additionally changed the usage of `var` with `let`. This is a best practice described [here](https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Writing_style_guide/Code_style_guide/JavaScript#variable_declarations)